### PR TITLE
fix ec2-api-endpoint not working issue

### DIFF
--- a/pkg/aws/endpoints/resolver.go
+++ b/pkg/aws/endpoints/resolver.go
@@ -16,7 +16,7 @@ var (
 )
 
 func Resolver(service, region string) (aws.Endpoint, error) {
-	if ep := operatorOption.Config.EC2APIEndpoint; len(ep) > 0 && service == "ec2" {
+	if ep := operatorOption.Config.EC2APIEndpoint; len(ep) > 0 && service == "EC2" {
 		log.Debugf("Using custom API endpoint %s for service %s in region %s", ep, service, region)
 		// See https://docs.aws.amazon.com/sdk-for-go/v2/api/aws/endpoints/#hdr-Using_Custom_Endpoints
 		return aws.Endpoint{


### PR DESCRIPTION
Version using: v1.14.6

Issue description:
We have setup proxy for aws service and need to set customized aws endpoint for cilium. We set the `ec2-api-endpoint: ec2.custom.com` in cilium config, but get error in cilium log:
```
level=fatal msg="Unable to init eni allocator" error="unable to update instance type to adapter limits from EC2 API: operation error EC2: DescribeInstanceTypes, exceeded maximum number of attempts, 3, https response error StatusCode: 0, RequestID: request send failed, Post "https://ec2.us-east-1.amazonaws.com/": EOF" subsys=cilium-operator
```

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```
